### PR TITLE
Label as compatible with FVTT 0.6.6

### DIFF
--- a/encounter-builder/module.json
+++ b/encounter-builder/module.json
@@ -4,7 +4,7 @@
   "description": "Adds an application to determine encounter difficulty, based on the Kobold Fight Club.",
   "version": "0.2.2",
   "minimumCoreVersion": "0.5.0",
-  "compatibleCoreVersion": "0.6.4",
+  "compatibleCoreVersion": "0.6.6",
   "author": "RaySSharma",
   "scripts": ["./src/encounter-builder.js", "./src/builder-form.js"],
   "styles": ["./css/encounter-builder.css"],


### PR DESCRIPTION
I've been using Encounter Builder with FVTT 0.6.6 for some time now and it works perfectly. This PR bumps the version compatibility list in order to eliminate the "Compatibility Risk" warning displayed in the UI.